### PR TITLE
add github project name to setup url arg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     long_description=long_description,
     keywords='certbot letsencrypt ssl certificate https secure encrypt encryption',
 
-    url='https://github.com/jaddison',
+    url='https://github.com/jaddison/certbot_py',
 
     author='jaddison',
     author_email='addi00+github.com@gmail.com',


### PR DESCRIPTION
otherwise PyPI links to user account rather than repository page

Perhaps linking to your GH profile rather than to the repo was intentional, but I figured it couldn't hurt to point it out just in case it wasn't...

Thanks for sharing your code!